### PR TITLE
Enable DateTime formatting and static properties

### DIFF
--- a/src/PSStringTemplate/AdapterUtil.cs
+++ b/src/PSStringTemplate/AdapterUtil.cs
@@ -1,0 +1,17 @@
+using System.Management.Automation;
+
+namespace PSStringTemplate
+{
+    internal static class AdapterUtil
+    {
+        internal static object NullIfEmpty(object value)
+        {
+            // Enable treating null-like values like empty strings and arrays from PSObject as null.
+            return value == null
+                ? null
+                : LanguagePrimitives.IsTrue(value)
+                    ? value
+                    : null;
+        }
+    }
+}

--- a/src/PSStringTemplate/NewStringTemplateGroupCommand.cs
+++ b/src/PSStringTemplate/NewStringTemplateGroupCommand.cs
@@ -1,3 +1,4 @@
+﻿using System;
 using System.Management.Automation;
 using Antlr4.StringTemplate;
 using Antlr4.StringTemplate.Misc;
@@ -30,6 +31,7 @@ namespace PSStringTemplate
             var groupInfo = new TemplateGroupInfo(group);
 
             group.RegisterModelAdaptor(typeof(PSObject), new PSObjectAdaptor());
+            group.RegisterModelAdaptor(typeof(Type), new TypeAdapter());
             group.RegisterRenderer(typeof(DateTime), new DateRenderer());
             group.RegisterRenderer(typeof(DateTimeOffset), new DateRenderer());
             group.Listener = ErrorManager.DefaultErrorListener;

--- a/src/PSStringTemplate/NewStringTemplateGroupCommand.cs
+++ b/src/PSStringTemplate/NewStringTemplateGroupCommand.cs
@@ -1,4 +1,4 @@
-﻿using System.Management.Automation;
+using System.Management.Automation;
 using Antlr4.StringTemplate;
 using Antlr4.StringTemplate.Misc;
 
@@ -30,6 +30,8 @@ namespace PSStringTemplate
             var groupInfo = new TemplateGroupInfo(group);
 
             group.RegisterModelAdaptor(typeof(PSObject), new PSObjectAdaptor());
+            group.RegisterRenderer(typeof(DateTime), new DateRenderer());
+            group.RegisterRenderer(typeof(DateTimeOffset), new DateRenderer());
             group.Listener = ErrorManager.DefaultErrorListener;
 
             WriteObject(groupInfo);

--- a/src/PSStringTemplate/PSStringTemplate.csproj
+++ b/src/PSStringTemplate/PSStringTemplate.csproj
@@ -63,6 +63,8 @@
   <ItemGroup>
     <Compile Include="MessageHelper.cs" />
     <Compile Include="PSObjectAdaptor.cs" />
+    <Compile Include="TypeAdapter.cs" />
+    <Compile Include="AdapterUtil.cs" />
     <Compile Include="TemplateGroupInfo.cs" />
     <Compile Include="ErrorListener.cs" />
     <Compile Include="GlobalSuppressions.cs" />

--- a/src/PSStringTemplate/TemplateGroupInfo.cs
+++ b/src/PSStringTemplate/TemplateGroupInfo.cs
@@ -1,4 +1,4 @@
-﻿using Antlr4.StringTemplate;
+using Antlr4.StringTemplate;
 using System.Collections.ObjectModel;
 using System.Management.Automation;
 using Antlr4.StringTemplate.Misc;
@@ -66,6 +66,8 @@ namespace PSStringTemplate
         {
             group.Listener = new ErrorListener(context);
             group.RegisterModelAdaptor(typeof(PSObject), new PSObjectAdaptor());
+            group.RegisterRenderer(typeof(DateTime), new DateRenderer());
+            group.RegisterRenderer(typeof(DateTimeOffset), new DateRenderer());
         }
 
         internal void Unbind()

--- a/src/PSStringTemplate/TemplateGroupInfo.cs
+++ b/src/PSStringTemplate/TemplateGroupInfo.cs
@@ -1,7 +1,9 @@
-using Antlr4.StringTemplate;
+﻿using Antlr4.StringTemplate;
+using Antlr4.StringTemplate.Misc;
 using System.Collections.ObjectModel;
 using System.Management.Automation;
-using Antlr4.StringTemplate.Misc;
+using System;
+
 using Strings = PSStringTemplate.Properties.Resources;
 
 namespace PSStringTemplate
@@ -66,6 +68,7 @@ namespace PSStringTemplate
         {
             group.Listener = new ErrorListener(context);
             group.RegisterModelAdaptor(typeof(PSObject), new PSObjectAdaptor());
+            group.RegisterModelAdaptor(typeof(Type), new TypeAdapter());
             group.RegisterRenderer(typeof(DateTime), new DateRenderer());
             group.RegisterRenderer(typeof(DateTimeOffset), new DateRenderer());
         }

--- a/src/PSStringTemplate/TypeAdapter.cs
+++ b/src/PSStringTemplate/TypeAdapter.cs
@@ -1,0 +1,46 @@
+using Antlr4.StringTemplate.Misc;
+using Antlr4.StringTemplate;
+using System;
+using System.Reflection;
+
+namespace PSStringTemplate
+{
+    public class TypeAdapter : ObjectModelAdaptor
+    {
+        public override object GetProperty(
+            Interpreter interpreter,
+            TemplateFrame frame,
+            object o,
+            object property,
+            string propertyName)
+        {
+            return GetProperty(o as Type, propertyName) ??
+                base.GetProperty(interpreter, frame, o, property, propertyName);
+        }
+
+        internal static object GetProperty(
+            Type type,
+            string propertyName)
+        {
+            if (type == null)
+            {
+                return null;
+            }
+
+            PropertyInfo typeProp = null;
+            try
+            {
+                typeProp = type
+                    .GetProperty(
+                        propertyName,
+                        BindingFlags.Static | BindingFlags.Public);
+            }
+            catch (AmbiguousMatchException)
+            {
+                // Treat ambiguous matches as if the property wasn't found
+            }
+
+            return AdapterUtil.NullIfEmpty(typeProp?.GetValue(null));
+        }
+    }
+}

--- a/test/Invoke-StringTemplate.tests.ps1
+++ b/test/Invoke-StringTemplate.tests.ps1
@@ -56,4 +56,27 @@ System.IO.DirectoryInfo - EnumerateFileSystemInfos - Method
         $cmdlet = New-Object PSStringTemplate.NewStringTemplateGroupCommand -Property @{ Definition = 'Test' }
         Invoke-StringTemplate -Definition '<_Definition>' $cmdlet | Should BeNullOrEmpty
     }
+    It 'can map static properties when input is a type' {
+        [DateTime] |
+            Invoke-StringTemplate -Definition '<Now>' |
+            Should Not BeNullOrEmpty
+    }
+    It 'adds instance properties of RuntimeType as well when bound by input' {
+        [DateTime] |
+            Invoke-StringTemplate -Definition '<IsPublic>' |
+            Should Be True
+    }
+    It 'can map static properties using the type adapter' {
+        Invoke-StringTemplate -Definition '<r.DefaultRunspace.RunspaceStateInfo.State>' @{
+            r = [runspace]
+        } | Should Be 'Opened'
+    }
+    It 'adds instance properties as well as static using the adapter' {
+        Invoke-StringTemplate -Definition '<r.IsPublic>' @{ r = [runspace] } |
+            Should Be True
+    }
+    It 'can format date using the date renderer' {
+        Invoke-StringTemplate -Definition '<d; format="yyyy.MM.dd">' @{ d = [DateTime]'1/1/90' } |
+            Should Be '1990.01.01'
+    }
 }


### PR DESCRIPTION
- Enable the use of static properties in attribute property binding and as template parameters from the pipeline

- Add the `DateRenderer` by default to enable formatting of `DateTime` objects within templates